### PR TITLE
fix: do not include locked accounts

### DIFF
--- a/mastodon-sitemap.py
+++ b/mastodon-sitemap.py
@@ -87,7 +87,7 @@ counter = 2
 while toots and counter < args.max_urls:
 	for toot in toots:
 		# only consider public toots
-		if toot.reblog or toot.visibility != "public":
+		if toot.reblog or toot.visibility != "public" or toot.account.locked:
 			continue
 		
 		# find when it was last modified


### PR DESCRIPTION
In the current settings, public toots by locked accounts are included in the sitemap but those toots are marked as noindex/noarchive. So i think we should remove those URLs from the sitemap.